### PR TITLE
Fix: Correct syntax errors in PowerShell error messages.

### DIFF
--- a/organize.ps1
+++ b/organize.ps1
@@ -117,7 +117,7 @@ $btnRun.Add_Click({
                     try {
                         New-Item -ItemType Directory -Force -Path $dir -ErrorAction Stop | Out-Null
                     } catch {
-                        Write-Output "[JOB_ERROR] Failed to create directory $dir: $($_.Exception.Message)"
+                        Write-Output "[JOB_ERROR] Failed to create directory ${dir}: $($_.Exception.Message)"
                     }
                 }
             }
@@ -152,12 +152,12 @@ $btnRun.Add_Click({
                     try {
                         Move-Item $file.FullName -Destination $dest -Force -ErrorAction Stop
                     } catch {
-                        Write-Output "[JOB_ERROR] Failed to move $($file.Name) to $dest: $($_.Exception.Message)"
+                        Write-Output "[JOB_ERROR] Failed to move $($file.Name) to ${dest}: $($_.Exception.Message)"
                     }
                     try {
                         Move-Item $metaPath -Destination $dest -Force -ErrorAction Stop
                     } catch {
-                        Write-Output "[JOB_ERROR] Failed to move $metaPath to $dest: $($_.Exception.Message)"
+                        Write-Output "[JOB_ERROR] Failed to move $metaPath to ${dest}: $($_.Exception.Message)"
                     }
                 }
             } else {
@@ -166,7 +166,7 @@ $btnRun.Add_Click({
                     try {
                         Move-Item $file.FullName -Destination $other -Force -ErrorAction Stop
                     } catch {
-                        Write-Output "[JOB_ERROR] Failed to move $($file.Name) to $other: $($_.Exception.Message)"
+                        Write-Output "[JOB_ERROR] Failed to move $($file.Name) to ${other}: $($_.Exception.Message)"
                     }
                 }
             }


### PR DESCRIPTION
The previous commit introduced try/catch blocks with Write-Output statements for error logging. These statements contained syntax errors due to how PowerShell parses variables followed by colons within interpolated strings (e.g., "$var: message").

This commit fixes these errors by explicitly delimiting the variable names with curly braces (e.g., "${var}: message"). This ensures correct parsing and resolves the "Variable reference is not valid" errors.

Affected lines in `organize.ps1` within the Start-Job script block's catch clauses have been updated for $dir, $dest, and $other variables used in error messages.